### PR TITLE
Fix width type for Cloudinary transformations

### DIFF
--- a/src/ai/services/cloudinary-client.service.ts
+++ b/src/ai/services/cloudinary-client.service.ts
@@ -5,8 +5,8 @@ export interface CloudinaryTransformation {
   effect?: string;
   quality?: string | number;
   format?: string;
-  width?: number;
-  height?: number;
+  width?: number | string;
+  height?: number | string;
   crop?: string;
   gravity?: string;
   overlay?: any;

--- a/src/ai/services/cloudinary.service.ts
+++ b/src/ai/services/cloudinary.service.ts
@@ -12,8 +12,8 @@ export interface CloudinaryTransformation {
   effect?: string;
   quality?: string | number;
   format?: string;
-  width?: number;
-  height?: number;
+  width?: number | string;
+  height?: number | string;
   crop?: string;
   gravity?: string;
   overlay?: any;


### PR DESCRIPTION
## Summary
- allow string values for `width` and `height` in Cloudinary transformation interfaces

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run type-check` *(fails: multiple existing TS errors)*
- `npm run build` *(fails: Module '"stream"' has no exported member 'promisify')*

------
https://chatgpt.com/codex/tasks/task_e_68438e61562083309609ff0e0a0a2be7